### PR TITLE
Fixing broken docs link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Out: <class 'multibar.impl.progressbars.Progressbar'>
 ```
 ### Documentation
 You can access the documentation by clicking on the following link:
-- [animatea.github.io/python-multibar](animatea.github.io/python-multibar/)
+- [animatea.github.io/python-multibar](https://animatea.github.io/python-multibar/)
 
 ### Examples
 Some more of the features of python-multibar are in the project examples.


### PR DESCRIPTION
It would also be really nice to have screen shots of the different status bars in the docs or (better) right in the README. Right now I'd be required to install it and run an example, and this is unlikely.